### PR TITLE
flyway version -> 5.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a seed project for Scalatra with Flyway for migrations and Anorm for db access. Steps to start a local server:
 1. `docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=root -d -p3306:3306 mysql:5.7`
-2. `mysql -uroot -h localhost --protocol tcp -proot`
+2. `mysql -uroot -h localhost --protocol tcp -proot -e "create database PUBLIC;"`
 3. `create database PUBLIC`
 4. `exit`
 5. `gradle mapprun`

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id "org.flywaydb.flyway" version "4.1.2"
+    id "org.flywaydb.flyway" version "5.2.4"
   	id "org.blinkmob.flywayrename" version "1.0.0"
 }
 


### PR DESCRIPTION
The latest version of gradle fails to run the currently specified version of flyway:

```
> Task :flywayMigrate FAILED
Task ':flywayMigrate' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:flywayMigrate (Thread[Daemon worker,5,main]) completed. Took 0.006 secs.
```

Upgrading to the current version of flyway solves this problem.